### PR TITLE
feat(Funding): Savings API Deprecations and Endpoint Reorganization

### DIFF
--- a/okx/Funding.py
+++ b/okx/Funding.py
@@ -1,20 +1,21 @@
 from .okxclient import OkxClient
 from .consts import *
+from typing import Optional, Dict, Any
 
 
 class FundingAPI(OkxClient):
 
     def __init__(
         self,
-        api_key="-1",
-        api_secret_key="-1",
-        passphrase="-1",
-        use_server_time=None,
-        flag="1",
-        domain="https://www.okx.com",
-        debug=False,
-        proxy=None,
-    ):
+        api_key: str = "-1",
+        api_secret_key: str = "-1",
+        passphrase: str = "-1",
+        use_server_time: Optional[bool] = None,
+        flag: str = "1",
+        domain: str = "https://www.okx.com",
+        debug: bool = False,
+        proxy: Optional[Dict[str, Any]] = None,
+    ) -> None:
         OkxClient.__init__(
             self,
             api_key,
@@ -28,37 +29,37 @@ class FundingAPI(OkxClient):
         )
 
     # Get Currencies
-    def get_currencies(self, ccy=""):
+    def get_currencies(self, ccy: str = ""):
         params = {"ccy": ccy}
         return self._request_with_params(GET, CURRENCY_INFO, params)
 
     # Get Balance
-    def get_balances(self, ccy=""):
+    def get_balances(self, ccy: str = ""):
         params = {"ccy": ccy}
         return self._request_with_params(GET, GET_BALANCES, params)
 
     # Get Non Tradable Assets
-    def get_non_tradable_assets(self, ccy=""):
+    def get_non_tradable_assets(self, ccy: str = ""):
         params = {"ccy": ccy}
         return self._request_with_params(GET, NON_TRADABLE_ASSETS, params)
 
     # Get Asset Valuation
-    def get_asset_valuation(self, ccy=""):
+    def get_asset_valuation(self, ccy: str = ""):
         params = {"ccy": ccy}
         return self._request_with_params(GET, ASSET_VALUATION, params)
 
     # Funds Transfer
     def funds_transfer(
         self,
-        ccy,
-        amt,
-        from_,
-        to,
-        type="0",
-        subAcct="",
-        loanTrans=False,
-        omitPosRisk=False,
-        clientId="",
+        ccy: str,
+        amt: str,
+        from_: str,
+        to: str,
+        type: str = "0",
+        subAcct: str = "",
+        loanTrans: bool = False,
+        omitPosRisk: bool = False,
+        clientId: str = "",
     ):
         params = {
             "ccy": ccy,
@@ -74,13 +75,21 @@ class FundingAPI(OkxClient):
         return self._request_with_params(POST, FUNDS_TRANSFER, params)
 
     # Get Transfer State
-    def transfer_state(self, transId="", clientId="", type=""):
+    def transfer_state(
+        self, transId: str = "", clientId: str = "", type: str = ""
+    ):
         params = {"transId": transId, "clientId": clientId, "type": type}
         return self._request_with_params(GET, TRANSFER_STATE, params)
 
     # Get Bills Info
     def get_bills(
-        self, ccy="", type="", clientId="", after="", before="", limit=""
+        self,
+        ccy: str = "",
+        type: str = "",
+        clientId: str = "",
+        after: str = "",
+        before: str = "",
+        limit: str = "",
     ):
         params = {
             "ccy": ccy,
@@ -93,22 +102,22 @@ class FundingAPI(OkxClient):
         return self._request_with_params(GET, BILLS_INFO, params)
 
     # Get Deposit Address
-    def get_deposit_address(self, ccy):
+    def get_deposit_address(self, ccy: str):
         params = {"ccy": ccy}
         return self._request_with_params(GET, DEPOSIT_ADDRESS, params)
 
     # Get Deposit History
     def get_deposit_history(
         self,
-        ccy="",
-        depId="",
-        fromWdId="",
-        txId="",
-        type="",
-        state="",
-        after="",
-        before="",
-        limit="",
+        ccy: str = "",
+        depId: str = "",
+        fromWdId: str = "",
+        txId: str = "",
+        type: str = "",
+        state: str = "",
+        after: str = "",
+        before: str = "",
+        limit: str = "",
     ):
         params = {
             "ccy": ccy,
@@ -126,14 +135,14 @@ class FundingAPI(OkxClient):
     # Withdrawal
     def withdrawal(
         self,
-        ccy,
-        amt,
-        dest,
-        toAddr,
-        chain="",
-        areaCode="",
-        rcvrInfo=None,
-        clientId="",
+        ccy: str,
+        amt: str,
+        dest: str,
+        toAddr: str,
+        chain: str = "",
+        areaCode: str = "",
+        rcvrInfo: Optional[Dict[str, str]] = None,
+        clientId: str = "",
     ):
         params = {
             "ccy": ccy,
@@ -149,22 +158,22 @@ class FundingAPI(OkxClient):
         return self._request_with_params(POST, WITHDRAWAL_COIN, params)
 
     # Cancel Withdrawal
-    def cancel_withdrawal(self, wdId=""):
+    def cancel_withdrawal(self, wdId: str = ""):
         params = {"wdId": wdId}
         return self._request_with_params(POST, CANCEL_WITHDRAWAL, params)
 
     # Get Withdrawal History
     def get_withdrawal_history(
         self,
-        ccy="",
-        wdId="",
-        clientId="",
-        txId="",
-        type="",
-        state="",
-        after="",
-        before="",
-        limit="",
+        ccy: str = "",
+        wdId: str = "",
+        clientId: str = "",
+        txId: str = "",
+        type: str = "",
+        state: str = "",
+        after: str = "",
+        before: str = "",
+        limit: str = "",
     ):
         params = {
             "ccy": ccy,
@@ -181,7 +190,12 @@ class FundingAPI(OkxClient):
 
     # Get Deposit Withdraw Status
     def get_deposit_withdraw_status(
-        self, wdId="", txId="", ccy="", to="", chain=""
+        self,
+        wdId: str = "",
+        txId: str = "",
+        ccy: str = "",
+        to: str = "",
+        chain: str = "",
     ):
         params = {
             "wdId": wdId,
@@ -195,13 +209,13 @@ class FundingAPI(OkxClient):
         )
 
     # Get Deposit Lightning
-    def get_deposit_lightning(self, ccy, amt, to=""):
+    def get_deposit_lightning(self, ccy: str, amt: str, to: str = ""):
         params = {"ccy": ccy, "amt": amt}
         if to:
             params = {"to": to}
         return self._request_with_params(GET, DEPOSIT_LIGHTNING, params)
 
     # Withdrawal Lightning
-    def withdrawal_lightning(self, ccy, invoice, memo=""):
+    def withdrawal_lightning(self, ccy: str, invoice: str, memo: str = ""):
         params = {"ccy": ccy, "invoice": invoice, "memo": memo}
         return self._request_with_params(POST, WITHDRAWAL_LIGHTNING, params)

--- a/okx/Funding.py
+++ b/okx/Funding.py
@@ -27,27 +27,27 @@ class FundingAPI(OkxClient):
             proxy,
         )
 
-    # Get Non Tradable Assets
-    def get_non_tradable_assets(self, ccy: str = ""):
+    # Get Currencies
+    def get_currencies(self, ccy=""):
         params = {"ccy": ccy}
-        return self._request_with_params(GET, NON_TRADABLE_ASSETS, params)
-
-    # Get Deposit Address
-    def get_deposit_address(self, ccy):
-        params = {"ccy": ccy}
-        return self._request_with_params(GET, DEPOSIT_ADDRESS, params)
-
-    # Get Transfer State
-    def transfer_state(self, transId, type=""):
-        params = {"transId": transId, "type": type}
-        return self._request_with_params(GET, TRANSFER_STATE, params)
+        return self._request_with_params(GET, CURRENCY_INFO, params)
 
     # Get Balance
     def get_balances(self, ccy=""):
         params = {"ccy": ccy}
         return self._request_with_params(GET, GET_BALANCES, params)
 
-    # Get Account Configuration
+    # Get Non Tradable Assets
+    def get_non_tradable_assets(self, ccy= ""):
+        params = {"ccy": ccy}
+        return self._request_with_params(GET, NON_TRADABLE_ASSETS, params)
+
+    # Get Asset Valuation
+    def get_asset_valuation(self, ccy=""):
+        params = {"ccy": ccy}
+        return self._request_with_params(GET, ASSET_VALUATION, params)
+
+    # Funds Transfer
     def funds_transfer(
         self,
         ccy,
@@ -56,9 +56,9 @@ class FundingAPI(OkxClient):
         to,
         type="0",
         subAcct="",
-        instId="",
-        toInstId="",
-        loanTrans="",
+        loanTrans=False,
+        omitPosRisk=False,
+        clientId="",
     ):
         params = {
             "ccy": ccy,
@@ -67,39 +67,46 @@ class FundingAPI(OkxClient):
             "to": to,
             "type": type,
             "subAcct": subAcct,
-            "instId": instId,
-            "toInstId": toInstId,
             "loanTrans": loanTrans,
+            "omitPosRisk": omitPosRisk,
+            "clientId": clientId,
         }
         return self._request_with_params(POST, FUNDS_TRANSFER, params)
 
-    # Withdrawal
-    def withdrawal(
-        self, ccy, amt, dest, toAddr, chain="", areaCode="", clientId=""
-    ):
+    # Get Transfer State
+    def transfer_state(self, transId="", clientId="", type=""):
+        params = {"transId": transId, "clientId": clientId, "type": type}
+        return self._request_with_params(GET, TRANSFER_STATE, params)
+
+    # Get Bills Info
+    def get_bills(self, ccy="", type="", clientId="", after="", before="", limit=""):
         params = {
             "ccy": ccy,
-            "amt": amt,
-            "dest": dest,
-            "toAddr": toAddr,
-            "chain": chain,
-            "areaCode": areaCode,
+            "type": type,
             "clientId": clientId,
+            "after": after,
+            "before": before,
+            "limit": limit,
         }
-        return self._request_with_params(POST, WITHDRAWAL_COIN, params)
+        return self._request_with_params(GET, BILLS_INFO, params)
+
+    # Get Deposit Address
+    def get_deposit_address(self, ccy):
+        params = {"ccy": ccy}
+        return self._request_with_params(GET, DEPOSIT_ADDRESS, params)
 
     # Get Deposit History
     def get_deposit_history(
         self,
         ccy="",
+        depId="",
+        fromWdId="",
+        txId="",
         type="",
         state="",
         after="",
         before="",
         limit="",
-        txId="",
-        depId="",
-        fromWdId="",
     ):
         params = {
             "ccy": ccy,
@@ -114,115 +121,29 @@ class FundingAPI(OkxClient):
         }
         return self._request_with_params(GET, DEPOSIT_HISTORY, params)
 
-    # Get Withdrawal History
-    def get_withdrawal_history(
-        self, ccy="", wdId="", state="", after="", before="", limit="", txId=""
+    # Withdrawal
+    def withdrawal(
+        self, ccy, amt, dest, toAddr, chain="", areaCode="", rcvrInfo=None, clientId=""
     ):
         params = {
             "ccy": ccy,
-            "wdId": wdId,
-            "state": state,
-            "after": after,
-            "before": before,
-            "limit": limit,
-            "txId": txId,
+            "amt": amt,
+            "dest": dest,
+            "toAddr": toAddr,
+            "chain": chain,
+            "areaCode": areaCode,
+            "clientId": clientId,
         }
-        return self._request_with_params(GET, WITHDRAWAL_HISTORY, params)
+        if rcvrInfo:
+            params["rcvrInfo"] = rcvrInfo
+        return self._request_with_params(POST, WITHDRAWAL_COIN, params)
 
-    # Get Currencies
-    def get_currencies(self, ccy=""):
-        params = {"ccy": ccy}
-        return self._request_with_params(GET, CURRENCY_INFO, params)
-
-    # PiggyBank Purchase/Redemption
-    def purchase_redempt(self, ccy, amt, side, rate):
-        params = {"ccy": ccy, "amt": amt, "side": side, "rate": rate}
-        return self._request_with_params(POST, PURCHASE_REDEMPT, params)
-
-    # Get Withdrawal History
-    def get_bills(self, ccy="", type="", after="", before="", limit=""):
-        params = {
-            "ccy": ccy,
-            "type": type,
-            "after": after,
-            "before": before,
-            "limit": limit,
-        }
-        return self._request_with_params(GET, BILLS_INFO, params)
-
-    # Get Deposit Lightning
-    def get_deposit_lightning(self, ccy, amt, to=""):
-        params = {"ccy": ccy, "amt": amt}
-        if to:
-            params = {"to": to}
-        return self._request_with_params(GET, DEPOSIT_LIGHTNING, params)
-
-    # Withdrawal Lightning
-    def withdrawal_lightning(self, ccy, invoice, memo=""):
-        params = {"ccy": ccy, "invoice": invoice, "memo": memo}
-        return self._request_with_params(POST, WITHDRAWAL_LIGHTNING, params)
-
-    # POST SET LENDING RATE
-    def set_lending_rate(self, ccy, rate):
-        params = {"ccy": ccy, "rate": rate}
-        return self._request_with_params(POST, SET_LENDING_RATE, params)
-
-    # GET LENDING HISTORY
-    def get_lending_history(self, ccy="", before="", after="", limit=""):
-        params = {"ccy": ccy, "after": after, "before": before, "limit": limit}
-        return self._request_with_params(GET, LENDING_HISTORY, params)
-
-    # GET LENDING RATE HISTORY
-    def get_lending_rate_history(self, ccy="", after="", before="", limit=""):
-        params = {"ccy": ccy, "after": after, "before": before, "limit": limit}
-        return self._request_with_params(GET, LENDING_RATE_HISTORY, params)
-
-    # GET LENDING RATE SUMMARY
-    def get_lending_rate_summary(self, ccy=""):
-        params = {"ccy": ccy}
-        return self._request_with_params(GET, LENDING_RATE_SUMMARY, params)
-
-    # POST /api/v5/asset/cancel-withdrawal
+    # Cancel Withdrawal
     def cancel_withdrawal(self, wdId=""):
         params = {"wdId": wdId}
         return self._request_with_params(POST, CANCEL_WITHDRAWAL, params)
 
-    # POST /api/v5/asset/convert-dust-assets
-    def convert_dust_assets(self, ccy=[]):
-        params = {"ccy": ccy}
-        return self._request_with_params(POST, CONVERT_DUST_ASSETS, params)
-
-    # GET /api/v5/asset/asset-valuation
-    def get_asset_valuation(self, ccy=""):
-        params = {"ccy": ccy}
-        return self._request_with_params(GET, ASSET_VALUATION, params)
-
-    # GET / api / v5 / asset / saving - balance
-    def get_saving_balance(self, ccy=""):
-        params = {"ccy": ccy}
-        return self._request_with_params(GET, GET_SAVING_BALANCE, params)
-
-    # Get non-tradable assets
-    def get_non_tradable_assets(self, ccy=""):
-        params = {"ccy": ccy}
-        return self._request_with_params(GET, GET_NON_TRADABLE_ASSETS, params)
-
-    # Get deposit withdraw status
-    def get_deposit_withdraw_status(
-        self, wdId="", txId="", ccy="", to="", chain=""
-    ):
-        params = {
-            "wdId": wdId,
-            "txId": txId,
-            "ccy": ccy,
-            "to": to,
-            "chain": chain,
-        }
-        return self._request_with_params(
-            GET, GET_DEPOSIT_WITHDrAW_STATUS, params
-        )
-
-    # Get withdrawal history
+    # Get Withdrawal History
     def get_withdrawal_history(
         self,
         ccy="",
@@ -246,4 +167,31 @@ class FundingAPI(OkxClient):
             "before": before,
             "limit": limit,
         }
-        return self._request_with_params(GET, GET_WITHDRAWAL_HISTORY, params)
+        return self._request_with_params(GET, WITHDRAWAL_HISTORY, params)
+
+    # Get Deposit Withdraw Status
+    def get_deposit_withdraw_status(
+        self, wdId="", txId="", ccy="", to="", chain=""
+    ):
+        params = {
+            "wdId": wdId,
+            "txId": txId,
+            "ccy": ccy,
+            "to": to,
+            "chain": chain,
+        }
+        return self._request_with_params(
+            GET, GET_DEPOSIT_WITHDRAW_STATUS, params
+        )
+
+    # Get Deposit Lightning
+    def get_deposit_lightning(self, ccy, amt, to=""):
+        params = {"ccy": ccy, "amt": amt}
+        if to:
+            params = {"to": to}
+        return self._request_with_params(GET, DEPOSIT_LIGHTNING, params)
+
+    # Withdrawal Lightning
+    def withdrawal_lightning(self, ccy, invoice, memo=""):
+        params = {"ccy": ccy, "invoice": invoice, "memo": memo}
+        return self._request_with_params(POST, WITHDRAWAL_LIGHTNING, params)

--- a/okx/Funding.py
+++ b/okx/Funding.py
@@ -38,7 +38,7 @@ class FundingAPI(OkxClient):
         return self._request_with_params(GET, GET_BALANCES, params)
 
     # Get Non Tradable Assets
-    def get_non_tradable_assets(self, ccy= ""):
+    def get_non_tradable_assets(self, ccy=""):
         params = {"ccy": ccy}
         return self._request_with_params(GET, NON_TRADABLE_ASSETS, params)
 
@@ -79,7 +79,9 @@ class FundingAPI(OkxClient):
         return self._request_with_params(GET, TRANSFER_STATE, params)
 
     # Get Bills Info
-    def get_bills(self, ccy="", type="", clientId="", after="", before="", limit=""):
+    def get_bills(
+        self, ccy="", type="", clientId="", after="", before="", limit=""
+    ):
         params = {
             "ccy": ccy,
             "type": type,
@@ -123,7 +125,15 @@ class FundingAPI(OkxClient):
 
     # Withdrawal
     def withdrawal(
-        self, ccy, amt, dest, toAddr, chain="", areaCode="", rcvrInfo=None, clientId=""
+        self,
+        ccy,
+        amt,
+        dest,
+        toAddr,
+        chain="",
+        areaCode="",
+        rcvrInfo=None,
+        clientId="",
     ):
         params = {
             "ccy": ccy,

--- a/okx/consts.py
+++ b/okx/consts.py
@@ -76,23 +76,23 @@ GET_VIP_LOAN_ORDER_LIST = "/api/v5/account/vip-loan-order-list"
 GET_VIP_LOAN_ORDER_DETAIL = "/api/v5/account/vip-loan-order-detail"
 
 # funding-complete-testcomplete
-CURRENCY_INFO = '/api/v5/asset/currencies'
-GET_BALANCES = '/api/v5/asset/balances'
-NON_TRADABLE_ASSETS = '/api/v5/asset/non-tradable-assets'
-ASSET_VALUATION = '/api/v5/asset/asset-valuation'
-FUNDS_TRANSFER = '/api/v5/asset/transfer'
-TRANSFER_STATE = '/api/v5/asset/transfer-state'
-BILLS_INFO = '/api/v5/asset/bills'
-DEPOSIT_ADDRESS = '/api/v5/asset/deposit-address'
-DEPOSIT_HISTORY = '/api/v5/asset/deposit-history'
-WITHDRAWAL_COIN = '/api/v5/asset/withdrawal'
-CANCEL_WITHDRAWAL = '/api/v5/asset/cancel-withdrawal'
-WITHDRAWAL_HISTORY = '/api/v5/asset/withdrawal-history'
-GET_DEPOSIT_WITHDRAW_STATUS = '/api/v5/asset/deposit-withdraw-status'
-EXCHANGE_LIST = '/api/v5/asset/exchange-list' # Need to add
-MONTHLY_STATEMENT = '/api/v5/asset/monthly-statement' # Need to add
-DEPOSIT_LIGHTNING = '/api/v5/asset/deposit-lightning'
-WITHDRAWAL_LIGHTNING = '/api/v5/asset/withdrawal-lightning'
+CURRENCY_INFO = "/api/v5/asset/currencies"
+GET_BALANCES = "/api/v5/asset/balances"
+NON_TRADABLE_ASSETS = "/api/v5/asset/non-tradable-assets"
+ASSET_VALUATION = "/api/v5/asset/asset-valuation"
+FUNDS_TRANSFER = "/api/v5/asset/transfer"
+TRANSFER_STATE = "/api/v5/asset/transfer-state"
+BILLS_INFO = "/api/v5/asset/bills"
+DEPOSIT_ADDRESS = "/api/v5/asset/deposit-address"
+DEPOSIT_HISTORY = "/api/v5/asset/deposit-history"
+WITHDRAWAL_COIN = "/api/v5/asset/withdrawal"
+CANCEL_WITHDRAWAL = "/api/v5/asset/cancel-withdrawal"
+WITHDRAWAL_HISTORY = "/api/v5/asset/withdrawal-history"
+GET_DEPOSIT_WITHDRAW_STATUS = "/api/v5/asset/deposit-withdraw-status"
+EXCHANGE_LIST = "/api/v5/asset/exchange-list"  # Need to add
+MONTHLY_STATEMENT = "/api/v5/asset/monthly-statement"  # Need to add
+DEPOSIT_LIGHTNING = "/api/v5/asset/deposit-lightning"
+WITHDRAWAL_LIGHTNING = "/api/v5/asset/withdrawal-lightning"
 
 # Convert-Complete
 GET_CURRENCIES = "/api/v5/asset/convert/currencies"

--- a/okx/consts.py
+++ b/okx/consts.py
@@ -76,30 +76,30 @@ GET_VIP_LOAN_ORDER_LIST = "/api/v5/account/vip-loan-order-list"
 GET_VIP_LOAN_ORDER_DETAIL = "/api/v5/account/vip-loan-order-detail"
 
 # funding-complete-testcomplete
-NON_TRADABLE_ASSETS = "/api/v5/asset/non-tradable-assets"
-DEPOSIT_ADDRESS = "/api/v5/asset/deposit-address"
-GET_BALANCES = "/api/v5/asset/balances"
-FUNDS_TRANSFER = "/api/v5/asset/transfer"
-TRANSFER_STATE = "/api/v5/asset/transfer-state"
-WITHDRAWAL_COIN = "/api/v5/asset/withdrawal"
-DEPOSIT_HISTORY = "/api/v5/asset/deposit-history"
-CURRENCY_INFO = "/api/v5/asset/currencies"
-PURCHASE_REDEMPT = "/api/v5/asset/purchase_redempt"
-BILLS_INFO = "/api/v5/asset/bills"
-DEPOSIT_LIGHTNING = "/api/v5/asset/deposit-lightning"
-WITHDRAWAL_LIGHTNING = "/api/v5/asset/withdrawal-lightning"
-CANCEL_WITHDRAWAL = "/api/v5/asset/cancel-withdrawal"  # need add
-WITHDRAWAL_HISTORY = "/api/v5/asset/withdrawal-history"
-CONVERT_DUST_ASSETS = "/api/v5/asset/convert-dust-assets"  # need add
-ASSET_VALUATION = "/api/v5/asset/asset-valuation"  # need add
-SET_LENDING_RATE = "/api/v5/asset/set-lending-rate"
-LENDING_HISTORY = "/api/v5/asset/lending-history"
-LENDING_RATE_HISTORY = "/api/v5/asset/lending-rate-history"
-LENDING_RATE_SUMMARY = "/api/v5/asset/lending-rate-summary"
-GET_SAVING_BALANCE = "/api/v5/asset/saving-balance"  # need to add
-GET_WITHDRAWAL_HISTORY = "/api/v5/asset/withdrawal-history"
-GET_NON_TRADABLE_ASSETS = "/api/v5/asset/non-tradable-assets"
-GET_DEPOSIT_WITHDrAW_STATUS = "/api/v5/asset/deposit-withdraw-status"
+CURRENCY_INFO = '/api/v5/asset/currencies'
+GET_BALANCES = '/api/v5/asset/balances'
+NON_TRADABLE_ASSETS = '/api/v5/asset/non-tradable-assets'
+ASSET_VALUATION = '/api/v5/asset/asset-valuation'
+FUNDS_TRANSFER = '/api/v5/asset/transfer'
+TRANSFER_STATE = '/api/v5/asset/transfer-state'
+BILLS_INFO = '/api/v5/asset/bills'
+DEPOSIT_ADDRESS = '/api/v5/asset/deposit-address'
+DEPOSIT_HISTORY = '/api/v5/asset/deposit-history'
+WITHDRAWAL_COIN = '/api/v5/asset/withdrawal'
+CANCEL_WITHDRAWAL = '/api/v5/asset/cancel-withdrawal'
+WITHDRAWAL_HISTORY = '/api/v5/asset/withdrawal-history'
+GET_DEPOSIT_WITHDRAW_STATUS = '/api/v5/asset/deposit-withdraw-status'
+EXCHANGE_LIST = '/api/v5/asset/exchange-list' # Need to add
+MONTHLY_STATEMENT = '/api/v5/asset/monthly-statement' # Need to add
+DEPOSIT_LIGHTNING = '/api/v5/asset/deposit-lightning'
+WITHDRAWAL_LIGHTNING = '/api/v5/asset/withdrawal-lightning'
+
+# Convert-Complete
+GET_CURRENCIES = "/api/v5/asset/convert/currencies"
+GET_CURRENCY_PAIR = "/api/v5/asset/convert/currency-pair"
+ESTIMATE_QUOTE = "/api/v5/asset/convert/estimate-quote"
+CONVERT_TRADE = "/api/v5/asset/convert/trade"
+CONVERT_HISTORY = "/api/v5/asset/convert/history"
 
 
 # Market Data-Complete-testComplete
@@ -236,13 +236,6 @@ MODIFY_SUBACCOUNT_DEPOSIT_ADDRESS = (
     "/api/v5/asset/broker/nd/modify-subaccount-deposit-address"
 )
 GET_SUBACCOUNT_DEPOSIT = "/api/v5/asset/broker/nd/subaccount-deposit-address"
-
-# Convert-Complete
-GET_CURRENCIES = "/api/v5/asset/convert/currencies"
-GET_CURRENCY_PAIR = "/api/v5/asset/convert/currency-pair"
-ESTIMATE_QUOTE = "/api/v5/asset/convert/estimate-quote"
-CONVERT_TRADE = "/api/v5/asset/convert/trade"
-CONVERT_HISTORY = "/api/v5/asset/convert/history"
 
 # FDBroker -completed
 FD_GET_REBATE_PER_ORDERS = "/api/v5/broker/fd/rebate-per-orders"

--- a/test/FundingTest.py
+++ b/test/FundingTest.py
@@ -11,79 +11,46 @@ class FundingTest(unittest.TestCase):
             api_key,
             api_secret_key,
             passphrase,
-            use_server_time=False,
             flag="0",
         )
 
-    """
-    CANCEL_WITHDRAWAL = '/api/v5/asset/cancel-withdrawal' #need add
-    CONVERT_DUST_ASSETS = '/api/v5/asset/convert-dust-assets' #need add
-    ASSET_VALUATION = '/api/v5/asset/asset-valuation' #need add
-    GET_SAVING_BALANCE = '/api/v5/asset/saving-balance' #need to add
-    def test_asset_evluation(self):
-        print(self.FundingAPI.get_asset_valuation("USDT"))
-    def test_dust_convert_asset(self):
-        print(self.FundingAPI.convert_dust_assets(["USDT"]))
-    def test_saving_balance(self):
-        print(self.FundingAPI.get_saving_balance())
-    def test_asset_get_currency(self):
-        print(self.FundingAPI.get_currency())
-    def test_get_balance(self):
+    # Test Get Currencies
+    def test_get_currencies(self):
+        print(self.FundingAPI.get_currencies("BTC"))
+
+    # Test Get Balances
+    def test_get_balances(self):
         print(self.FundingAPI.get_balances())
-    def test_transfer(self):
-        print(self.FundingAPI.funds_transfer("USDT","100","6","18"))
+
+    # Test Get Non Tradable Assets
+    def test_get_non_tradable_assets(self):
+        print(self.FundingAPI.get_non_tradable_assets())
+
+    # Test Get Asset Valuation
+    def test_get_asset_valuation(self):
+        print(self.FundingAPI.get_asset_valuation("USDT"))
+
+    # Test Funds Transfer
+    def test_funds_transfer(self):
+        print(self.FundingAPI.funds_transfer("USDT", "100", "6", "18"))
+
+    # Test Get Transfer State
     def test_transfer_state(self):
         print(self.FundingAPI.transfer_state("11"))
+
+    # Test Get Bills Info
     def test_get_bills(self):
         print(self.FundingAPI.get_bills())
-    def test_deposit_lighting(self):
-        print(self.FundingAPI.get_deposit_lightning("BTC","10"))
+
+    # Test Get Deposit Address
     def test_get_deposit_address(self):
         print(self.FundingAPI.get_deposit_address("BTC"))
+
+    # Test Get Deposit History
     def test_get_deposit_history(self):
         print(self.FundingAPI.get_deposit_history())
-    def test_withdraw(self):
-        print(self.FundingAPI.coin_withdraw(ccy="USDT",amt = '10.0',dest = '3',toAddr="1391224291",fee="10"))
-    def test_lighting_withdrawl(self):
-        print(self.FundingAPI.withdrawal_lightning("BTC","jdsnjvhofhenogvne",memo="222"))
-    def test_cancel_withdrawl(self):
-        print(self.FundingAPI.cancel_withdrawal("sdhiadhsfdjknvjdaodns"))
-    def test_get_withdrawal_history(self):
-        print(self.FundingAPI.get_withdrawal_history())
-    def test_purchase_redempt(self):
-        print(self.FundingAPI.purchase_redempt("BTC",'1.0','purchase','0.1'))
-    def test_set_lending_rate(self):
-        print(self.FundingAPI.set_lending_rate("USDT","0.1"))
-    def test_get_lending_history(self):
-        print(self.FundingAPI.get_lending_history(ccy="USDT"))
-    def test_get_lending_summary(self):
-        print(self.FundingAPI.get_lending_rate_summary('BTC'))
-    def test_get_lending_rate_history(self):
-        print(self.FundingAPI.get_lending_rate_history())
-        
-    def test_get_lending_summary(self):
-        print(self.FundingAPI.get_lending_rate_summary('BTC'))
-    """
 
-    # def test_get_non_tradable_assets(self):
-    #     print(self.FundingAPI.get_non_tradable_assets())
-    # def test_get_lending_summary(self):
-    #     print(self.FundingAPI.get_lending_rate_summary('BTC'))
-    # def test_get_lending_rate_history(self):
-    #     print(self.FundingAPI.get_lending_rate_history())
-
-    # def test_get_non_tradable_assets(self):
-    #     print(self.FundingAPI.get_non_tradable_assets())
-
-    # def test_get_deposit_withdraw_status(self):
-    #     print(self.FundingAPI.get_deposit_withdraw_status(wdId='84804812'))
-
-    # def test_get_withdrawal_history(self):
-    #     print(self.FundingAPI.get_withdrawal_history())
-
-    # def test_get_deposit_history(self):
-    #     print(self.FundingAPI.get_deposit_history())
-
+    # Test Withdrawal
     def test_withdrawal(self):
         print(
             self.FundingAPI.withdrawal(
@@ -94,6 +61,27 @@ class FundingTest(unittest.TestCase):
                 areaCode="86",
             )
         )
+
+    # Test Cancel Withdrawal
+    def test_cancel_withdrawal(self):
+        print(self.FundingAPI.cancel_withdrawal("sdhiadhsfdjknvjdaodns"))
+
+    # Test Get Withdrawal History
+    def test_get_withdrawal_history(self):
+        print(self.FundingAPI.get_withdrawal_history())
+
+    # Test Get Deposit Withdraw Status
+    def test_get_deposit_withdraw_status(self):
+        print(self.FundingAPI.get_deposit_withdraw_status(wdId="84804812"))
+
+    # Test Get Deposit Lightning
+    def test_get_deposit_lightning(self):
+        print(self.FundingAPI.get_deposit_lightning("BTC", "10"))
+
+    # Test Withdrawal Lightning
+    def test_withdrawal_lightning(self):
+        print(self.FundingAPI.withdrawal_lightning("BTC", "jdsnjvhofhenogvne", memo="222"))
+
 
 
 if __name__ == "__main__":

--- a/test/FundingTest.py
+++ b/test/FundingTest.py
@@ -80,8 +80,11 @@ class FundingTest(unittest.TestCase):
 
     # Test Withdrawal Lightning
     def test_withdrawal_lightning(self):
-        print(self.FundingAPI.withdrawal_lightning("BTC", "jdsnjvhofhenogvne", memo="222"))
-
+        print(
+            self.FundingAPI.withdrawal_lightning(
+                "BTC", "jdsnjvhofhenogvne", memo="222"
+            )
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Deprecated API Endpoints

The following Savings-related API endpoints have been officially deprecated as of January 22, 2024:

- /api/v5/asset/saving-balance
- /api/v5/asset/purchase_redempt
- /api/v5/asset/set-lending-rate
-  /api/v5/asset/lending-history
-  /api/v5/asset/lending-rate-summary
- /api/v5/asset/lending-rate-history

These endpoints are no longer functional and have been replaced by the new Savings module endpoints.

## Sorted API Endpoints

Endpoints are now organized based on the official documentation structure, making it easier for users to locate and understand the changes.
