### PR TITLE
fix(Funding): Enhance funding unittest and Fix wrong parameter in withdrawal lightning function

### DIFF
--- a/okx/Funding.py
+++ b/okx/Funding.py
@@ -216,6 +216,8 @@ class FundingAPI(OkxClient):
         return self._request_with_params(GET, DEPOSIT_LIGHTNING, params)
 
     # Withdrawal Lightning
-    def withdrawal_lightning(self, ccy: str, invoice: str, memo: str = ""):
-        params = {"ccy": ccy, "invoice": invoice, "memo": memo}
+    def withdrawal_lightning(
+        self, ccy: str, invoice: str, rcvrInfo: Dict[str, str] = {}
+    ):
+        params = {"ccy": ccy, "invoice": invoice, "rcvrInfo": rcvrInfo}
         return self._request_with_params(POST, WITHDRAWAL_LIGHTNING, params)

--- a/test/FundingTest.py
+++ b/test/FundingTest.py
@@ -6,7 +6,7 @@ class FundingTest(unittest.TestCase):
     def setUp(self):
         api_key = "your_apiKey"
         api_secret_key = "your_secretKey"
-        passphrase = "your_secretKey"
+        passphrase = "your_passphrase"
         self.FundingAPI = Funding.FundingAPI(
             api_key,
             api_secret_key,
@@ -16,75 +16,130 @@ class FundingTest(unittest.TestCase):
 
     # Test Get Currencies
     def test_get_currencies(self):
-        print(self.FundingAPI.get_currencies("BTC"))
+        with self.FundingAPI as funding:
+            result = funding.get_currencies(ccy="BTC")
+            status_code = result.get("code")
+            self.assertEqual(status_code, "0")
 
     # Test Get Balances
     def test_get_balances(self):
-        print(self.FundingAPI.get_balances())
+        with self.FundingAPI as funding:
+            result = funding.get_balances()
+            status_code = result.get("code")
+            self.assertEqual(status_code, "0")
 
     # Test Get Non Tradable Assets
     def test_get_non_tradable_assets(self):
-        print(self.FundingAPI.get_non_tradable_assets())
+        with self.FundingAPI as funding:
+            result = funding.get_non_tradable_assets()
+            status_code = result.get("code")
+            self.assertEqual(status_code, "0")
 
     # Test Get Asset Valuation
     def test_get_asset_valuation(self):
-        print(self.FundingAPI.get_asset_valuation("USDT"))
+        with self.FundingAPI as funding:
+            result = funding.get_asset_valuation(ccy="USDT")
+            status_code = result.get("code")
+            self.assertEqual(status_code, "0")
 
     # Test Funds Transfer
     def test_funds_transfer(self):
-        print(self.FundingAPI.funds_transfer("USDT", "100", "6", "18"))
+        with self.FundingAPI as funding:
+            result = funding.funds_transfer(
+                ccy="USDT", amt="100", from_="6", to="18"
+            )
+            status_code = result.get("code")
+            self.assertEqual(status_code, "0")
 
     # Test Get Transfer State
     def test_transfer_state(self):
-        print(self.FundingAPI.transfer_state("11"))
+        with self.FundingAPI as funding:
+            result = funding.transfer_state(transId="11")
+            status_code = result.get("code")
+            self.assertEqual(status_code, "0")
 
     # Test Get Bills Info
     def test_get_bills(self):
-        print(self.FundingAPI.get_bills())
+        with self.FundingAPI as funding:
+            result = funding.get_bills()
+            status_code = result.get("code")
+            self.assertEqual(status_code, "0")
 
     # Test Get Deposit Address
     def test_get_deposit_address(self):
-        print(self.FundingAPI.get_deposit_address("BTC"))
+        with self.FundingAPI as funding:
+            result = funding.get_deposit_address(ccy="BTC")
+            status_code = result.get("code")
+            self.assertEqual(status_code, "0")
 
     # Test Get Deposit History
     def test_get_deposit_history(self):
-        print(self.FundingAPI.get_deposit_history())
+        with self.FundingAPI as funding:
+            result = funding.get_deposit_history()
+            status_code = result.get("code")
+            self.assertEqual(status_code, "0")
 
     # Test Withdrawal
     def test_withdrawal(self):
-        print(
-            self.FundingAPI.withdrawal(
+        with self.FundingAPI as funding:
+            result = funding.withdrawal(
                 ccy="USDT",
                 amt="1",
                 dest="3",
                 toAddr="18740405107",
                 areaCode="86",
             )
-        )
+            status_code = result.get("code")
+            self.assertEqual(status_code, "0")
 
     # Test Cancel Withdrawal
     def test_cancel_withdrawal(self):
-        print(self.FundingAPI.cancel_withdrawal("sdhiadhsfdjknvjdaodns"))
+        with self.FundingAPI as funding:
+            result = funding.cancel_withdrawal(wdId="sdhiadhsfdjknvjdaodns")
+            status_code = result.get("code")
+            self.assertEqual(status_code, "0")
 
     # Test Get Withdrawal History
     def test_get_withdrawal_history(self):
-        print(self.FundingAPI.get_withdrawal_history())
+        with self.FundingAPI as funding:
+            result = funding.get_withdrawal_history()
+            status_code = result.get("code")
+            self.assertEqual(status_code, "0")
 
     # Test Get Deposit Withdraw Status
     def test_get_deposit_withdraw_status(self):
-        print(self.FundingAPI.get_deposit_withdraw_status(wdId="84804812"))
+        with self.FundingAPI as funding:
+            result = funding.get_deposit_withdraw_status(wdId="84804812")
+            status_code = result.get("code")
+            self.assertEqual(status_code, "0")
 
     # Test Get Deposit Lightning
     def test_get_deposit_lightning(self):
-        print(self.FundingAPI.get_deposit_lightning("BTC", "10"))
+        with self.FundingAPI as funding:
+            result = funding.get_deposit_lightning(ccy="BTC", amt="10")
+            status_code = result.get("code")
+            self.assertEqual(status_code, "0")
 
     # Test Withdrawal Lightning
     def test_withdrawal_lightning(self):
-        print(
-            self.FundingAPI.withdrawal_lightning(
-                "BTC", "jdsnjvhofhenogvne", memo="222"
+        with self.FundingAPI as funding:
+            rcvrInfo = {
+                "walletType": "exchange",
+                "exchId": "did:ethr:0xfeb4f99829a9acdf52979abee87e83addf22a7e1",
+                "rcvrFirstName": "Bruce",
+                "rcvrLastName": "Wayne",
+                "rcvrCountry": "United States",
+                "rcvrCountrySubDivision": "California",
+                "rcvrTownName": "San Jose",
+                "rcvrStreetName": "Clementi Avenue 1",
+            }
+            result = funding.withdrawal_lightning(
+                ccy="BTC",
+                invoice="lnbc100u1psnnvhtpp5yq2x3q5hhrzsuxpwx7ptphwzc4k4wk0j3stp0099968m44cyjg9sdqqcqzpgxqzjcsp5hz",
+                rcvrInfo=rcvrInfo,
             )
-        )
+            status_code = result.get("code")
+            self.assertEqual(status_code, "0")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Note:

The parameters for the `withdrawal_lightning` function follow the example provided in the [OKX API documentation](https://www.okx.com/docs-v5/log_zh/#2024-08-08-withdrawal-api-adjustment-for-bahama-entity-users) under the changelog dated 2024-08-08 regarding the withdrawal API adjustments for Bahama entity users.